### PR TITLE
chore(deps): consolidate dependency updates & bump to v1.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2261,9 +2261,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -776,10 +776,11 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "AdminLTE",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "EUPL-1.2",
       "devDependencies": {
         "autoprefixer": "^10.4.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "AdminLTE",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "description": "",
   "repository": {


### PR DESCRIPTION
This Pull Request consolidates the following Dependabot updates and bumps the project version to `v1.0.3`:

- #15: Bump fast-uri from 3.1.3 to 3.1.4
- #14: Bump brace-expansion from 1.1.11 to 1.1.16

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates dependency updates and bumps the project to `v1.0.3`. Upgrades `brace-expansion` to `1.1.16` and `fast-uri` to `3.1.4`.

<sup>Written for commit e58c37f49a8750d58fae4a5b66c91255be5c138a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/NickJLange/AdminLTE/pull/16?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 1.0.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->