### PR TITLE
chore(deps): consolidate dependency updates & bump to v1.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3346,9 +3346,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2263,9 +2263,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "AdminLTE",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "EUPL-1.2",
       "devDependencies": {
         "autoprefixer": "^10.4.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "AdminLTE",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "description": "",
   "repository": {


### PR DESCRIPTION
This Pull Request consolidates the following Dependabot updates and bumps the project version to `v1.0.5`:

- #21: Bump js-yaml from 4.3.0 to 4.3.1
- #20: Bump fast-uri from 3.1.4 to 3.1.5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates two Dependabot dependency updates (`fast-uri` 3.1.4 → 3.1.5, `js-yaml` 4.3.0 → 4.3.1) and bumps the project version to `v1.0.5`. Both are dev dependencies with no expected behavior changes or migration steps.

<sup>Written for commit f7c490ee72e608219a03a9ad46f959923f0d66bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/NickJLange/AdminLTE/pull/22?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Incremented the application version to 1.0.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->